### PR TITLE
Fix segmentation fault in SentenceDataFlow

### DIFF
--- a/src/server/data/SentenceDataFlow.cpp
+++ b/src/server/data/SentenceDataFlow.cpp
@@ -119,7 +119,7 @@ Text SentenceDataFlow::getData() {
 
     getPreData(result);
 
-    if(result[result.size() -1].type != FINAL) {
+    if(!result.empty() && result[result.size() -1].type != FINAL) {
         int startTime;
         int stopTime;
         if(currentSent.text.compare("") == 0) {


### PR DESCRIPTION
Due to a missing check the SentenceDataFlow will segfault upon accessing the empty `result` vector.
Fix this by adding the missing check for emptiness.